### PR TITLE
Fix Dev Container Build Error (Go Version)

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bullseye
+FROM golang:1.23-bullseye
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR fixes a build failure in GitHub Codespaces due to an outdated Go version.

❌ The go.mod file requires Go >= 1.23.0, but the current dev container uses Go 1.22.12, causing this error:

```
go: go.mod requires go >= 1.23.0 (running go 1.22.12; GOTOOLCHAIN=local)
```

✅ Tested in GitHub Codespaces. The container now builds successfully.
